### PR TITLE
Allow using Date as a value

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -94,4 +94,20 @@ describe("sql template tag", () => {
       expect(query.values).toEqual([]);
     });
   });
+
+  describe("value typing", () => {
+    it.each([
+      ["string", "Blake"],
+      ["number", 123],
+      ["boolean", true],
+      ["Date", new Date("2010-01-01T00:00:00Z")],
+      ["null", null],
+      ["undefined", undefined],
+      ["string array", ["Blake", "Taylor"]],
+      ["object", { name: "Blake" }],
+    ])("should allow using %s as a value", (_type, value) => {
+      const query = sql`UPDATE user SET any_value = ${value}`;
+      expect(query.values).toEqual([value]);
+    });
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export type Value =
   | string
   | number
   | boolean
+  | Date
   | null
   | undefined
   | Value[]


### PR DESCRIPTION
Both [pg](https://www.npmjs.com/package/pg) and [mysql](https://www.npmjs.com/package/mysql) allow you to pass Date instances as values and do the correct transformation for you.

This was allowed in sql-template-tag as well until the `Value` type was made more strict in https://github.com/blakeembrey/sql-template-tag/commit/d1fb92ec5653a5680f0bf9abfbecd4518b56bef4.