### PR TITLE
Check for nested `sql` query after 'IN' keyword.

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -72,6 +72,13 @@ describe("sql template tag", () => {
     );
   });
 
+  it("should throw when a value after 'IN' keyword is not nested sql", () => {
+    const ids = [1, 2, 3];
+    expect(() => sql`SELECT * FROM books WHERE id IN (${ids})`).toThrowError(
+      "Expected a value after 'IN' keyword should be the nested sql queries"
+    );
+  });
+
   it("should inspect sql instance", () => {
     expect(inspect(sql`SELECT * FROM test`)).toContain(`'SELECT * FROM test'`);
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,20 @@ export class Sql {
       const child = rawValues[i++];
       const rawString = rawStrings[i];
 
+      // Check for nested `sql` query after IN keyword in development environment
+      if (
+        process.env.NODE_ENV === "development" ||
+        process.env.NODE_ENV === "test"
+      ) {
+        if (rawStrings[i - 1].endsWith("IN (")) {
+          if (!(child instanceof Sql)) {
+            throw new TypeError(
+              "Expected a value after 'IN' keyword should be the nested sql queries"
+            );
+          }
+        }
+      }
+
       // Check for nested `sql` queries.
       if (child instanceof Sql) {
         // Append child prefix text to current string.

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,7 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "types": []
-  },
   "exclude": ["src/**/*.spec.ts"]
 }


### PR DESCRIPTION
Hi @blakeembrey!

First, thanks for the helpful open source!

I use this for Prisma raw query very well, but I think it would be helpful if the error is thrown when using the array value after 'IN' keyword in the raw query by mistake.

It is not easy to find what is error in that case.
Could you review this PR?

I would like to do this PR as part of [hacktoberfest](https://hacktoberfest.com/). Would you add the label "HACKTOBERFEST-ACCEPTED" to this PR?

Thanks!
