### PR TITLE
Fix test scripts to include format scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lint": "ts-scripts lint",
     "prepare": "ts-scripts install && ts-scripts build",
     "specs": "ts-scripts specs",
-    "test": "ts-scripts test"
+    "test": "npm run format && ts-scripts test"
   },
   "files": [
     "dist/"


### PR DESCRIPTION
Hi @blakeembrey!

I get another PR.

Currently, test scripts failed when the prettier format was not applied.

```
[warn] tsconfig.json
[warn] Code style issues found in the above file(s). Forgot to run Prettier?
❌ "prettier" exited with 1
``` 

Thus, it would be helpful if the format script should be run before the test script.

Or, it would be helpful if [ts-scripts](https://github.com/borderless/ts-scripts)'s test step adds the format step to the existing steps:  ```check, specs, and build```

If you apply this, it would help developers to test easily!

What do you think?

Thank you!

