### PR TITLE
Support flowtype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage/
 .DS_Store
 npm-debug.log
 dist/
+.idea

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "bugs": {
     "url": "https://github.com/blakeembrey/sql-template-tag/issues"
   },
+  "main": "./dist/index.js",
   "type": "module",
   "exports": "./dist/index.js",
   "engines": {


### PR DESCRIPTION
Hi,

I am using flowtype instead of typescript. Flowtype hasn't updated to support ESM yet, so it still requires the `main` field to be present in `package.json` in order to work.

Without the `main` field, I get this error:

```
$ /Users/yatchee/dev/test/node_modules/.bin/flow check
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ index.js:3:17

Cannot resolve module sql-template-tag.
[cannot-resolve-module]

     1│ // @flow
     2│
     3│ import sql from 'sql-template-tag'
     4│
     5│ const query = sql`SELECT * FROM Anywhere;`
     6│ console.log('query', query)
```

I believe keeping the main field, or putting it back in, should not affect typescript users, so I think this can be a minor or patch level update.

Peace!