### PR TITLE
Add native support for OracleDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,12 @@ const query = sql`SELECT * FROM books WHERE id = ${id}`;
 
 query.sql; //=> "SELECT * FROM books WHERE id = ?"
 query.text; //=> "SELECT * FROM books WHERE id = $1"
+query.statement; //=> "SELECT * FROM books WHERE id = :1"
 query.values; //=> [id]
 
 pg.query(query); // Uses `text` and `values`.
 mysql.query(query); // Uses `sql` and `values`.
+oracledb.execute(query); // Uses `statement` and `values`.
 
 // Embed SQL instances inside SQL instances.
 const nested = sql`SELECT id FROM authors WHERE name = ${"Blake"}`;
@@ -86,18 +88,12 @@ query.values; //=> ["Blake", "Bob", "Joe"]
 
 ## Recipes
 
-This package "just works" with [`pg`](https://www.npmjs.com/package/pg), [`mysql`](https://www.npmjs.com/package/mysql) and [`sqlite`](https://www.npmjs.com/package/sqlite).
+This package "just works" with [`pg`](https://www.npmjs.com/package/pg), [`mysql`](https://www.npmjs.com/package/mysql), [`sqlite`](https://www.npmjs.com/package/sqlite) and [`oracledb`](https://www.npmjs.com/package/node-oracledb).
 
 ### [MSSQL](https://www.npmjs.com/package/mssql)
 
 ```js
 mssql.query(query.strings, ...query.values);
-```
-
-### [OracleDB](https://github.com/oracle/node-oracledb)
-
-```js
-session.execute(query.statement, query.values);
 ```
 
 ### Stricter TypeScript

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "es6",
     "pg",
     "postgres",
-    "mysql"
+    "mysql",
+    "oracledb",
+    "oracle"
   ],
   "homepage": "https://github.com/blakeembrey/sql-template-tag",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sql-template-tag",
   "version": "5.2.0",
-  "description": "ES2015 tagged template string for preparing SQL statements, works with `pg` and `mysql`",
+  "description": "ES2015 tagged template string for preparing SQL statements, works with `pg`, `mysql`, `sqlite` and `oracledb`",
   "keywords": [
     "sql",
     "template",
@@ -12,6 +12,7 @@
     "pg",
     "postgres",
     "mysql",
+    "sqlite",
     "oracledb",
     "oracle"
   ],


### PR DESCRIPTION
## Background

After you've implemented #37 I opened an enhancement request for the node-oracledb driver (see oracle/node-oracledb#1629). This was accepted and implemented in version 6.4.0 of the node-oracledb driver. Oracle also opened a PR for the type definition (see DefinitelyTyped/DefinitelyTyped#69327). This PR has been accepted and is now included in version 6.4.0 of [@types/oracldb](https://www.npmjs.com/package/@types/oracledb) on npm.

So, OracleDB is now a first-class citizen as PostgreSQL and MySQL (when using sql-template-tag >=5.2.0, node-oracledb >=6.4.0 and @types/oracledb >=6.4.0).

## Change

This PR updates the README regarding `query.statement` and `query.values` which are now automatically considered by the latest node-oracledb driver.