### PR TITLE
Native support for server-side JavaScript in Oracle Database 23ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ query.values; //=> ["Blake", "Bob", "Joe"]
 
 ## Recipes
 
-This package "just works" with [`pg`](https://www.npmjs.com/package/pg), [`mysql`](https://www.npmjs.com/package/mysql), [`sqlite`](https://www.npmjs.com/package/sqlite) and [`oracledb`](https://www.npmjs.com/package/node-oracledb).
+This package "just works" with [`pg`](https://www.npmjs.com/package/pg), [`mysql`](https://www.npmjs.com/package/mysql), [`sqlite`](https://www.npmjs.com/package/sqlite). Support for Oracle Database is available for both client ([`oracledb`](https://www.npmjs.com/package/node-oracledb)) and server mode ([Multilingual Engine/JavaScript](https://docs.oracle.com/en/database/oracle/oracle-database/23/mlejs/index.html)), the latter since Oracle Database 23ai for Linux x86-64 ([API documentation](https://oracle-samples.github.io/mle-modules/docs/mle-js-oracledb/23ai/classes/api.IConnection.html#execute)).
 
 ### [MSSQL](https://www.npmjs.com/package/mssql)
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "mysql",
     "sqlite",
     "oracledb",
+    "Multilingual Engine/JavaScript"
     "oracle"
   ],
   "homepage": "https://github.com/blakeembrey/sql-template-tag",


### PR DESCRIPTION
## Background

Based on #41 and issues raised with both `oracledb` (cf [`oracledb` issue 1629](https://github.com/oracle/node-oracledb/issues/1629)) and the database team at Oracle, support for `sql-template-tag` was added for JavaScript "stored procedures". Multilingual Engine, powered by GraalVM, allows developers to write business logic in JavaScript in addition to PL/SQL. Oracle Database 23ai, Release Update 5 on Linux x86-64 introduces support for `sql-template-tag` in the JavaScript SQL Driver in addition to client-side `oracledb`.

## Change

Based on #41 both `readme.md` and `package.json` have been modified.