### PR TITLE
Add support for duckdb

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -29,6 +29,9 @@ describe("sql template tag", () => {
     expect(query.sql).toEqual("SELECT * FROM books WHERE author = ?");
     expect(query.text).toEqual("SELECT * FROM books WHERE author = $1");
     expect(query.statement).toEqual("SELECT * FROM books WHERE author = :1");
+    expect(query.duckdb).toEqual(
+      "SELECT * FROM books WHERE author = ?::VARCHAR",
+    );
     expect(query.values).toEqual([name]);
   });
 


### PR DESCRIPTION
DuckDB has a unique way of formatting arguments that requires the type be specified after a `?::` for positional arguments. 

I added support for my own use case and it seems to work well.

DuckDB documentation: https://duckdb.org/docs/api/nodejs/overview